### PR TITLE
Provisioning should respect the slave template's exclusivity setting. 

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/azure/AzureCloud.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureCloud.java
@@ -136,8 +136,14 @@ public class AzureCloud extends Cloud {
 	/** Returns slave template associated with the label */
 	public AzureSlaveTemplate getAzureSlaveTemplate(Label label) {
 		for (AzureSlaveTemplate slaveTemplate : instTemplates) {
-			if (label.matches(slaveTemplate.getLabelDataSet())) {
-				return slaveTemplate;
+			if (slaveTemplate.getUseSlaveAlwaysIfAvail() == Node.Mode.NORMAL) {
+				if (label == null || label.matches(slaveTemplate.getLabelDataSet())) {
+					return slaveTemplate;
+				}
+			} else if (slaveTemplate.getUseSlaveAlwaysIfAvail() == Node.Mode.EXCLUSIVE) {
+				if (label != null && label.matches(slaveTemplate.getLabelDataSet())) {
+					return slaveTemplate;
+				}
 			}
 		}
 		return null;
@@ -269,8 +275,8 @@ public class AzureCloud extends Cloud {
 				try {
 					slave.toComputer().waitUntilOnline();
 				} catch (InterruptedException e) {
-                	 // just ignore
-                }
+					 // just ignore
+				}
 				return "success";
 			}
 		};


### PR DESCRIPTION
Also fixes a crash with a null label.
