### PR TITLE
Check whether slave has an associated computer before attempting to set offline

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/azure/AzureCloud.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureCloud.java
@@ -303,9 +303,9 @@ public class AzureCloud extends Cloud {
 	
 	private static void markSlaveForDeletion(AzureSlave slave, String message) {
 		slave.setTemplateStatus(Constants.TEMPLATE_STATUS_DISBALED, message);
-        if (slave.toComputer() != null) {
-            slave.toComputer().setTemporarilyOffline(true, OfflineCause.create(Messages._Slave_Failed_To_Connect()));
-        }
+		if (slave.toComputer() != null) {
+			slave.toComputer().setTemporarilyOffline(true, OfflineCause.create(Messages._Slave_Failed_To_Connect()));
+		}
 		slave.setDeleteSlave(true);
 	}
 	


### PR DESCRIPTION
This is already the case in the SSH slave code, but not in this code.  Sometimes a slave will have a null computer if it failed somewhere during the provisioning/startup stage.
