### PR TITLE
Fixed NPE when verifing template with my image on storage account with affinity group.

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/azure/AzureManagementServiceDelegate.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureManagementServiceDelegate.java
@@ -1808,8 +1808,9 @@ public class AzureManagementServiceDelegate {
 					}
 				}
 				
-				if (imageProps!= null && !imageProps.get(ImageProperties.LOCATION).contains(location)) {
-					return Messages.Azure_GC_Template_ImageFamilyOrID_LOC_No_Match(imageProps.get(ImageProperties.LOCATION)) +saValidation;
+				String storageLocation = imageProps.get(ImageProperties.LOCATION);
+				if (imageProps!= null && storageLocation != null && !storageLocation.contains(location)) {
+					return Messages.Azure_GC_Template_ImageFamilyOrID_LOC_No_Match(storageLocation) +saValidation;
 				}
 				
 				if(imageProps!= null && (!Constants.OS_TYPE_WINDOWS.equalsIgnoreCase(imageProps.get(ImageProperties.OSTYPE)) && 


### PR DESCRIPTION
A NullPointerException occurred when verifying template with the image id of my image that stored storage account with affinity group to `[Image Family or Id]` field.

![2015-01-23 10 55 00](https://cloud.githubusercontent.com/assets/678656/5868539/5ad29408-a2ee-11e4-8a06-de2ec31a4961.png)

When getting properties of storage account that has affinity group with `com.microsoft.windowsazure.management.storage.StorageAccountOperations#get`, the location property that includes that repsonse is `null` . That causes NPE when verifyng location on `AzureManagementServiceDelegate`.

For specification of the `com.microsoft.windowsazure.management.storage.StorageAccountOperations#get`, Please see the following documents. 
https://msdn.microsoft.com/library/azure/ee460802.aspx#bk_storageproperties

This PR fixes it. 