### PR TITLE
fix for two bugs when using shutdownOnIdle option (azure-slave-plugin)

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/azure/AzureCloudRetensionStrategy.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureCloudRetensionStrategy.java
@@ -25,66 +25,58 @@ import com.microsoftopentechnologies.azure.util.Constants;
 import com.microsoftopentechnologies.azure.util.ExecutionEngine;
 
 import hudson.model.Descriptor;
-import hudson.slaves.OfflineCause;
 import hudson.slaves.RetentionStrategy;
 import hudson.util.TimeUnit2;
 
 public class AzureCloudRetensionStrategy extends RetentionStrategy<AzureComputer>  {
-	public final int idleTerminationMinutes;
+	public final long idleTerminationMillis;
 	private static final Logger LOGGER = Logger.getLogger(AzureManagementServiceDelegate.class.getName());
 
 	@DataBoundConstructor
 	public AzureCloudRetensionStrategy(int idleTerminationMinutes) {
-		this.idleTerminationMinutes = idleTerminationMinutes;
+		this.idleTerminationMillis = TimeUnit2.MINUTES.toMillis(idleTerminationMinutes);
 	}
 
 	public long check(final AzureComputer slaveNode) {
         // if idleTerminationMinutes is zero then it means that never terminate the slave instance 
-		if  (idleTerminationMinutes == 0) {
-        	return 1;
-        }
-		
-        // Do we need to check about slave status?
-		if (slaveNode.isIdle()) {
-            if (idleTerminationMinutes > 0) {
-            	final long idleMilliseconds = System.currentTimeMillis() - slaveNode.getIdleStartMilliseconds();
-                if (idleMilliseconds > TimeUnit2.MINUTES.toMillis(idleTerminationMinutes)) {
-                	// close channel
-                	try {
-                		slaveNode.setAcceptingTasks(false);
-                		slaveNode.disconnect(OfflineCause.create(Messages._IDLE_TIMEOUT_SHUTDOWN()));
-                		if (slaveNode.getChannel() != null ) {
-    						slaveNode.getChannel().close();
-                		}
-                	} catch (Exception e) {
-    					e.printStackTrace();
-    					LOGGER.info("AzureCloudRetensionStrategy: check: exception occured while closing channel for: "+slaveNode.getName());
-    				}
-                    LOGGER.info("AzureCloudRetensionStrategy: check: Idle timeout reached for slave: "+slaveNode.getName());
-                   
-                    java.util.concurrent.Callable<Void> task = new java.util.concurrent.Callable<Void>() {
-            			public Void call() throws Exception {
-            				LOGGER.info("AzureCloudRetensionStrategy: going to idleTimeout slave: "+slaveNode.getName());
-            				slaveNode.getNode().idleTimeout();
-            				return null;
-            			}
-            		};
-            		
-            		try {
-            			ExecutionEngine.executeWithRetry(task,  new LinearRetryForAllExceptions(30 /*maxRetries*/, 30/*waitinterval*/, 30 * 60/*timeout*/));
-					} catch (AzureCloudException ae) {
-            			LOGGER.info("AzureCloudRetensionStrategy: check: could not terminate or shutdown "+slaveNode.getName());
-					} catch (Exception e) {
-						LOGGER.info("AzureCloudRetensionStrategy: execute: Exception occured while calling timeout on node, \n"
-									+ "Error code "+e.getMessage());
-						// We won't get exception for RNF , so for other exception types we can retry
-						if (e.getMessage().contains("not found in the currently deployed service")) {
-							LOGGER.info("AzureCloudRetensionStrategy: execute: Slave does not exist in the subscription anymore, setting shutdownOnIdle to True");
-							slaveNode.getNode().setShutdownOnIdle(true);
-						}
-					}
+        // an active node or one that is not yet up and running are ignored as well
+        if (idleTerminationMillis > 0 && slaveNode.isIdle() && slaveNode.isProvisioned()
+                && idleTerminationMillis < (System.currentTimeMillis() - slaveNode.getIdleStartMilliseconds())) {
+            // block node for further tasks
+            slaveNode.setAcceptingTasks(false);
+            LOGGER.info("AzureCloudRetensionStrategy: check: Idle timeout reached for slave: "+slaveNode.getName());
+
+            java.util.concurrent.Callable<Void> task = new java.util.concurrent.Callable<Void>() {
+                public Void call() throws Exception {
+                    LOGGER.info("AzureCloudRetensionStrategy: going to idleTimeout slave: "+slaveNode.getName());
+                    slaveNode.getNode().idleTimeout();
+                    return null;
                 }
-            } 
+            };
+
+            try {
+                ExecutionEngine.executeWithRetry(task,  new LinearRetryForAllExceptions(30 /*maxRetries*/, 30/*waitinterval*/, 30 * 60/*timeout*/));
+            } catch (AzureCloudException ae) {
+                LOGGER.info("AzureCloudRetensionStrategy: check: could not terminate or shutdown "+slaveNode.getName());
+            } catch (Exception e) {
+                LOGGER.info("AzureCloudRetensionStrategy: execute: Exception occured while calling timeout on node, \n"
+                            + "Error code "+e.getMessage());
+                // We won't get exception for RNF , so for other exception types we can retry
+                if (e.getMessage().contains("not found in the currently deployed service")) {
+                    LOGGER.info("AzureCloudRetensionStrategy: execute: Slave does not exist in the subscription anymore, setting shutdownOnIdle to True");
+                    slaveNode.getNode().setShutdownOnIdle(true);
+                }
+            }
+            // close channel
+            try {
+                slaveNode.setProvisioned(false);
+                if (slaveNode.getChannel() != null) {
+                    slaveNode.getChannel().close();
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                LOGGER.info("AzureCloudRetensionStrategy: check: exception occured while closing channel for: " + slaveNode.getName());
+            }
         }
         return 1;
 	}

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureComputer.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureComputer.java
@@ -26,6 +26,7 @@ import hudson.slaves.OfflineCause;
 
 public class AzureComputer extends AbstractCloudComputer<AzureSlave>  {
 	private static final Logger LOGGER = Logger.getLogger(AzureComputer.class.getName());
+	private boolean provisioned = false;
 
 	public AzureComputer(AzureSlave slave) {
 		super(slave);
@@ -33,6 +34,20 @@ public class AzureComputer extends AbstractCloudComputer<AzureSlave>  {
 	
 	public AzureSlave getNode() {
         return (AzureSlave)super.getNode();
+    }
+
+    public void setProvisioned(boolean provisioned) {
+        this.provisioned = provisioned;
+    }
+
+    public boolean isProvisioned() {
+        return this.provisioned;
+    }
+
+    @Override
+    public void waitUntilOnline() throws InterruptedException {
+        super.waitUntilOnline();
+        setProvisioned(true);
     }
 	
 	public HttpResponse doDoDelete() throws IOException {

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureSlave.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureSlave.java
@@ -37,6 +37,7 @@ import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.ComputerLauncher;
+import hudson.slaves.OfflineCause;
 import hudson.slaves.RetentionStrategy;
 
 public class AzureSlave extends AbstractCloudSlave  {
@@ -247,6 +248,7 @@ public class AzureSlave extends AbstractCloudSlave  {
 			// Call shutdown only if the slave is online
 			if (this.getComputer().isOnline()) {
 				LOGGER.info("AzureSlave: idleTimeout: shutdownOnIdle is true, shutting down slave "+this.getDisplayName());
+				this.getComputer().disconnect(OfflineCause.create(Messages._IDLE_TIMEOUT_SHUTDOWN()));
 				AzureManagementServiceDelegate.shutdownVirtualMachine(this);
 				setDeleteSlave(false);
 			}


### PR DESCRIPTION
When using the **shutdownOnIdle** option, I encountered two problems:
1. the actual shutdown (when triggered by the *AzureRetensionStrategy*) was always failing with an EOFException, which was caused by first closing the slave node's channel and then trying to get its online status (via the closed channel).
2. when a new job was requesting an existing (i.e. previously shutdown) node to be started again, the internal idleStartInMillis was not reset and the next check by the *AzureRetensionStrategy* forced that node to stop again even though it hadn't even reached its online status again.

I already mentioned the first problem in [JENKINS-24649](https://issues.jenkins-ci.org/browse/JENKINS-24649?focusedCommentId=231771&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-231771).
