### PR TITLE
use azure-publishersettings-credentials to set service subscription

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.509</version>
+		<version>1.609</version>
 	</parent>
 
 	<artifactId>azure-slave-plugin</artifactId>
-	<version>0.3.4-SNAPSHOT</version>
+	<version>0.4.0-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 	<name>Azure Slave Plugin</name>
 	<description>Provisions slave on Azure cloud</description>
@@ -113,12 +113,18 @@
       		<artifactId>bcprov-jdk16</artifactId>
       		<version>1.46</version>
     	</dependency>
-		
-		<dependency>
-			<groupId>com.jcraft</groupId>
-			<artifactId>jsch</artifactId>
-			<version>0.1.51</version>
-		</dependency>
+
+      <dependency>
+      	<groupId>com.jcraft</groupId>
+      	<artifactId>jsch</artifactId>
+      	<version>0.1.51</version>
+      </dependency>
+
+      <dependency>
+      	<groupId>org.jenkins-ci.plugins</groupId>
+      	<artifactId>azure-publishersettings-credentials</artifactId>
+      	<version>1.0</version>
+      </dependency>
 
     </dependencies>
 	

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureCloud.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureCloud.java
@@ -492,6 +492,9 @@ public class AzureCloud extends Cloud {
 		public FormValidation doVerifyConfiguration(@QueryParameter String credentialsId, @QueryParameter String passPhrase) {
 
 			AzurePublisherSettings credentials = resolveCredentials(credentialsId);
+			if (credentials == null) {
+				return FormValidation.error("Invalid credentials");
+			}
 
 			String response = AzureManagementServiceDelegate.verifyConfiguration(
 					credentials.getSubscriptionId(), credentials.getServiceManagementCert(), passPhrase, credentials.getServiceManagementUrl());

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureManagementServiceDelegate.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureManagementServiceDelegate.java
@@ -560,6 +560,7 @@ public class AzureManagementServiceDelegate {
 			LOGGER.info("AzureManagementServiceDelegate: parseDeploymentResponse: no of executors "+template.getNoOfParallelJobs());
 			AzureCloud azureCloud = template.getAzureCloud();
 			AzurePublisherSettings credentials = azureCloud.getCredentials();
+			if (credentials == null) throw new AzureCloudException("No credentials set");
 			return new AzureSlave(params.getRoleName(), template.getTemplateName(),
 					template.getTemplateDesc(), osType, template.getSlaveWorkSpace(),
 					template.getNoOfParallelJobs(),

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureSlaveTemplate.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureSlaveTemplate.java
@@ -341,6 +341,7 @@ public class AzureSlaveTemplate implements Describable<AzureSlaveTemplate> {
 	
 	public int getVirtualMachineCount() throws Exception {
 		final AzurePublisherSettings credentials = azureCloud.getCredentials();
+		if (credentials == null) throw new AzureCloudException("No credentials set");
 
 		Configuration config = ServiceDelegateHelper.loadConfiguration(credentials.getSubscriptionId(),
 				credentials.getServiceManagementCert(), azureCloud.getPassPhrase(), credentials.getServiceManagementUrl());

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureTemplateMonitorTask.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureTemplateMonitorTask.java
@@ -26,6 +26,7 @@ import hudson.model.AsyncPeriodicWork;
 import hudson.model.TaskListener;
 import hudson.model.Hudson;
 import com.microsoftopentechnologies.azure.util.Constants;
+import org.jenkinsci.plugins.azure.AzurePublisherSettings;
 
 @Extension
 public final class AzureTemplateMonitorTask extends AsyncPeriodicWork {
@@ -67,7 +68,9 @@ public final class AzureTemplateMonitorTask extends AsyncPeriodicWork {
 	public synchronized static void registerTemplate(AzureSlaveTemplate template) {
 		if (templates == null) 
 			templates = new HashMap<String, String>();
-		templates.put(template.getTemplateName(), Constants.AZURE_CLOUD_PREFIX+template.getAzureCloud().getCredentials().getSubscriptionId());
+		final AzurePublisherSettings credentials = template.getAzureCloud().getCredentials();
+		if (credentials == null) throw new IllegalStateException("No credentials set");
+		templates.put(template.getTemplateName(), Constants.AZURE_CLOUD_PREFIX + credentials.getSubscriptionId());
 	}
 
 	public long getRecurrencePeriod() {

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureTemplateMonitorTask.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureTemplateMonitorTask.java
@@ -67,7 +67,7 @@ public final class AzureTemplateMonitorTask extends AsyncPeriodicWork {
 	public synchronized static void registerTemplate(AzureSlaveTemplate template) {
 		if (templates == null) 
 			templates = new HashMap<String, String>();
-		templates.put(template.getTemplateName(), Constants.AZURE_CLOUD_PREFIX+template.getAzureCloud().getSubscriptionId());
+		templates.put(template.getTemplateName(), Constants.AZURE_CLOUD_PREFIX+template.getAzureCloud().getCredentials().getSubscriptionId());
 	}
 
 	public long getRecurrencePeriod() {

--- a/src/main/resources/com/microsoftopentechnologies/azure/AzureCloud/config.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/azure/AzureCloud/config.jelly
@@ -1,26 +1,17 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
 	<f:section title="${%Azure_Profile_Configuration}">
-		<f:entry title="${%Subscription_ID}" field="subscriptionId" help="/plugin/azure-slave-plugin/help-subscriptionId.html">
-			<f:textbox />
+		<f:entry title="${%Subscription Credential}" field="credentialsId">
+			<c:select />
 		 </f:entry>
 		 
-		<f:entry title="${%Service_Management_Certificate}" field="serviceManagementCert" help="/plugin/azure-slave-plugin/help-serviceManagementCert.html">
-			<f:password />
-		</f:entry>
-		
 		<f:entry title="${%Max_Virtual_Machines_Limit}" field="maxVirtualMachinesLimit" help="/plugin/azure-slave-plugin/help-maxVirtualMachinesLimit.html">
 				<f:textbox default="${descriptor.getDefaultMaxVMLimit()}" />
 		</f:entry>
 		
-		<f:advanced>
-			<f:entry title="${%Service_Management_URL}" field="serviceManagementURL" help="/plugin/azure-slave-plugin/help-serviceManagementURL.html">
-		    	<f:textbox default="${descriptor.getDefaultserviceManagementURL()}" />
-		  	</f:entry>
-		</f:advanced>
-		 		 
-		<f:validateButton title="${%Verify_Configuration}" progress="${%Verifying}" method="verifyConfiguration" with="subscriptionId,serviceManagementCert,passPhrase,serviceManagementURL" />
+
+		<f:validateButton title="${%Verify_Configuration}" progress="${%Verifying}" method="verifyConfiguration" with="credentialsId, passPhrase" />
 	</f:section>
 	
 	<f:entry title="${%Azure_Virtual_Machine_Template}" description="${%Azure_Virtual_Machine_Template_desc}">

--- a/src/main/resources/com/microsoftopentechnologies/azure/AzureCloud/help-credentialsId.html
+++ b/src/main/resources/com/microsoftopentechnologies/azure/AzureCloud/help-credentialsId.html
@@ -1,0 +1,26 @@
+<!--
+  ~ The MIT License
+  ~
+  ~  Copyright (c) 2015, CloudBees, Inc.
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the "Software"), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  ~
+  -->
+
+Azure Publisher Settings Credentials matching your Azure Subscription.

--- a/src/main/resources/com/microsoftopentechnologies/azure/AzureSlaveTemplate/config.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/azure/AzureSlaveTemplate/config.jelly
@@ -98,7 +98,7 @@
 				</div>
 			</f:entry>
 			<f:validateButton title="${%Verify_Template}" progress="${%Verifying_Template_MSG}" method="verifyConfiguration" 
-			with="subscriptionId,serviceManagementCert,passPhrase,serviceManagementURL,maxVirtualMachinesLimit,templateName,labels,location,virtualMachineSize,storageAccountName,
+			with="credentialsId,passPhrase,maxVirtualMachinesLimit,templateName,labels,location,virtualMachineSize,storageAccountName,
 			noOfParallelJobs,imageIdOrFamily,slaveLaunchMethod,initScript,adminUserName,adminPassword,virtualNetworkName,subnetName,retentionTimeInMin,cloudServiceName,templateStatus,jvmOptions" />
 			
 		</table>

--- a/src/main/webapp/help-serviceManagementCert.html
+++ b/src/main/webapp/help-serviceManagementCert.html
@@ -1,6 +1,0 @@
-<div>
-	Provide a service management certificate (as a Base64 encoded string).
-	
-	If you are using an Azure publish settings file, copy the content of the ManagementCertificate attribute of a Subscription element.
-	If you do not have an Azure publish settings file, you can download one from <a href="https://manage.windowsazure.com/publishsettings/Index?SchemaVersion=2.0" target="_blank">here.</a>
-</div>

--- a/src/main/webapp/help-serviceManagementURL.html
+++ b/src/main/webapp/help-serviceManagementURL.html
@@ -1,5 +1,0 @@
-<div>
-	Leave unchanged if you are using the public Microsoft Azure cloud.
-	If you are using a private or other Azure cloud service, enter the management service endpoint URL for that cloud.
-	You can get this information from the Azure portal.
-</div>

--- a/src/main/webapp/help-subscriptionId.html
+++ b/src/main/webapp/help-subscriptionId.html
@@ -1,7 +1,0 @@
-<div>
-	Enter an Azure subscription ID.
-	
-	You can get this information from the Azure portal or from an Azure publish settings file.
-	
-	If you don't have an Azure publish settings file, you can download one from <a href="https://manage.windowsazure.com/publishsettings/Index?SchemaVersion=2.0" target="_blank">here</a>
-</div>


### PR DESCRIPTION
I've released [azure-publishersettings-credentials](https://github.com/jenkinsci/azure-publishersettings-credentials-plugin) plugin which I'm using in another (proprietary) plugin to interact with Azure to manage service subscription using Jenkins Credentials API.

This PR handle data migration so azure-slave plugin do use the same credential store without requirement to reconfigure jenkins.
