### PR TITLE
Fix node retention across restarts

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/azure/AzureCloud.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureCloud.java
@@ -230,7 +230,6 @@ public class AzureCloud extends Cloud {
 												 Hudson.getInstance().addNode(slaveNode);
 												 if (slaveNode.getSlaveLaunchMethod().equalsIgnoreCase("SSH")) { 
 													 slaveNode.toComputer().connect(false).get();
-													 azureComputer.setProvisioned(true);
 												 } else {
 													// Wait until node is online
 													 waitUntilOnline(slaveNode);
@@ -265,7 +264,6 @@ public class AzureCloud extends Cloud {
 									 LOGGER.info("Azure Cloud: provision: Adding slave to azure nodes ");
 									 Hudson.getInstance().addNode(slave);
 									 slave.toComputer().connect(false).get();
-									 ((AzureComputer) slave.toComputer()).setProvisioned(true);
 								 } else if (slave.getSlaveLaunchMethod().equalsIgnoreCase("JNLP")) {
 									 LOGGER.info("Azure Cloud: provision: Checking for slave status");
 									 // slaveTemplate.waitForReadyRole(slave);

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureCloudRetensionStrategy.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureCloudRetensionStrategy.java
@@ -53,11 +53,10 @@ public class AzureCloudRetensionStrategy extends RetentionStrategy<AzureComputer
         }
     }
 
-	private long _check(final AzureComputer slaveNode) {
+    private long _check(final AzureComputer slaveNode) {
         // if idleTerminationMinutes is zero then it means that never terminate the slave instance 
         // an active node or one that is not yet up and running are ignored as well
-        if (idleTerminationMillis > 0 && slaveNode.isIdle() && slaveNode.isProvisioned()
-                && idleTerminationMillis < (System.currentTimeMillis() - slaveNode.getIdleStartMilliseconds())) {
+        if (idleTerminationMillis > 0 && slaveNode.isIdle() && idleTerminationMillis < (System.currentTimeMillis() - slaveNode.getIdleStartMilliseconds())) {
             // block node for further tasks
             slaveNode.setAcceptingTasks(false);
             LOGGER.info("AzureCloudRetensionStrategy: check: Idle timeout reached for slave: "+slaveNode.getName());
@@ -72,7 +71,6 @@ public class AzureCloudRetensionStrategy extends RetentionStrategy<AzureComputer
             }
             // close channel? Need to see if below code solved any issues.
             try {
-                slaveNode.setProvisioned(false);
                 if (slaveNode.getChannel() != null) {
                     slaveNode.getChannel().close();
                 }

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureComputer.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureComputer.java
@@ -26,7 +26,6 @@ import hudson.slaves.OfflineCause;
 
 public class AzureComputer extends AbstractCloudComputer<AzureSlave>  {
 	private static final Logger LOGGER = Logger.getLogger(AzureComputer.class.getName());
-	private boolean provisioned = false;
 
 	public AzureComputer(AzureSlave slave) {
 		super(slave);
@@ -36,18 +35,9 @@ public class AzureComputer extends AbstractCloudComputer<AzureSlave>  {
         return (AzureSlave)super.getNode();
     }
 
-    public void setProvisioned(boolean provisioned) {
-        this.provisioned = provisioned;
-    }
-
-    public boolean isProvisioned() {
-        return this.provisioned;
-    }
-
     @Override
     public void waitUntilOnline() throws InterruptedException {
         super.waitUntilOnline();
-        setProvisioned(true);
     }
 	
 	public HttpResponse doDoDelete() throws IOException {


### PR DESCRIPTION
Nodes are retained across restarts and never reclaimed in case of idle.  This is because the provisioned flag is not saved in the slave configuration.  Doing so isn't actually necessary.  If the node is idle and an Azure slave, we implicitly know it's provisioned.