### PR TITLE
Optimize slave cleanup

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/azure/AzureCloud.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureCloud.java
@@ -238,7 +238,7 @@ public class AzureCloud extends Cloud {
 												 azureComputer.setAcceptingTasks(true);
 												 return slaveNode;
 											} else {
-												slaveNode.setDeleteSlave(true);
+												slaveNode.setCleanupAction(CleanupAction.TERMINATE);
 											}
 										} catch (Exception e) {
 											// TODO Auto-generated catch block
@@ -329,8 +329,8 @@ public class AzureCloud extends Cloud {
 	 */
 	private static boolean isNodeEligibleForReuse(AzureSlave slaveNode, AzureSlaveTemplate slaveTemplate) {
 
-		// Do not reuse slave if it is marked for deletion.  
-		if (slaveNode.isDeleteSlave()) {
+		// Do not reuse slave if it is marked for deletion
+		if (slaveNode.getCleanupAction() != CleanupAction.TERMINATE) {
 			return false;
 		}
 		
@@ -351,7 +351,7 @@ public class AzureCloud extends Cloud {
 		if (slave.toComputer() != null) {
 			slave.toComputer().setTemporarilyOffline(true, OfflineCause.create(Messages._Slave_Failed_To_Connect()));
 		}
-		slave.setDeleteSlave(true);
+		slave.setCleanupAction(CleanupAction.TERMINATE);
 	}
 	
 	public void doProvision(StaplerRequest req, StaplerResponse rsp, @QueryParameter String templateName) throws Exception {

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureCloudRetensionStrategy.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureCloudRetensionStrategy.java
@@ -56,20 +56,27 @@ public class AzureCloudRetensionStrategy extends RetentionStrategy<AzureComputer
 	private long _check(final AzureComputer slaveNode) {
         // if idleTerminationMinutes is zero then it means that never terminate the slave instance 
         // an active node or one that is not yet up and running are ignored as well
-        if (idleTerminationMillis > 0 && slaveNode.isIdle() && slaveNode.isProvisioned()
-                && idleTerminationMillis < (System.currentTimeMillis() - slaveNode.getIdleStartMilliseconds())) {
-            // block node for further tasks
-            slaveNode.setAcceptingTasks(false);
+        if (idleTerminationMillis > 0 && slaveNode.isIdle() && 
+                idleTerminationMillis < (System.currentTimeMillis() - slaveNode.getIdleStartMilliseconds())) {
+            // If the node is already marked for shutdown/deletion, then skip
+            if (slaveNode.getNode().getCleanupAction() != CleanupAction.NONE) {
+                return 1;
+            }
             LOGGER.info("AzureCloudRetensionStrategy: check: Idle timeout reached for slave: "+slaveNode.getName());
 
+            // block node for further tasks
+            slaveNode.setAcceptingTasks(false);
+            
             try {
+                // Call idle timeout, which will set the machine offline appropriately based on its 
+                // properties (shutdown or delete when idle)
             	slaveNode.getNode().idleTimeout();
             } catch (AzureCloudException ae) {
                 LOGGER.info("AzureCloudRetensionStrategy: check: could not terminate or shutdown "+slaveNode.getName()+ " Error code "+ae.getMessage());
             } catch (Exception e) {
                 LOGGER.info("AzureCloudRetensionStrategy: check: could not terminate or shutdown "+slaveNode.getName()+ "Error code "+e.getMessage());
-                
             }
+            
             // close channel? Need to see if below code solved any issues.
             try {
                 slaveNode.setProvisioned(false);

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureCloudRetensionStrategy.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureCloudRetensionStrategy.java
@@ -68,24 +68,10 @@ public class AzureCloudRetensionStrategy extends RetentionStrategy<AzureComputer
             slaveNode.setAcceptingTasks(false);
             
             try {
-                // Call idle timeout, which will set the machine offline appropriately based on its 
-                // properties (shutdown or delete when idle)
-            	slaveNode.getNode().idleTimeout();
-            } catch (AzureCloudException ae) {
-                LOGGER.info("AzureCloudRetensionStrategy: check: could not terminate or shutdown "+slaveNode.getName()+ " Error code "+ae.getMessage());
-            } catch (Exception e) {
-                LOGGER.info("AzureCloudRetensionStrategy: check: could not terminate or shutdown "+slaveNode.getName()+ "Error code "+e.getMessage());
-            }
-            
-            // close channel? Need to see if below code solved any issues.
-            try {
-                slaveNode.setProvisioned(false);
-                if (slaveNode.getChannel() != null) {
-                    slaveNode.getChannel().close();
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-                LOGGER.info("AzureCloudRetensionStrategy: check: exception occured while closing channel for: " + slaveNode.getName());
+               slaveNode.getNode().idleTimeout();
+            } 
+            catch (Exception e) {
+                LOGGER.info("AzureCloudRetensionStrategy: check: could not perform idle shutdown/delete prep for "+slaveNode.getName()+ " Error code "+e.getMessage());
             }
         }
         return 1;

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureComputer.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureComputer.java
@@ -68,9 +68,7 @@ public class AzureComputer extends AbstractCloudComputer<AzureSlave>  {
 		LOGGER.info("AzureComputer : deleteSlave: Deleting " + getName() + " slave");
 	
 		AzureSlave slave = getNode();
-		if (slave.getChannel() != null) {
-			slave.getChannel().close();
-		}
+		this.setTemporarilyOffline(true, OfflineCause.create(Messages._Delete_Slave()));
 		try {
 			slave.cleanup();
 		} catch (Exception e) {

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureComputer.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureComputer.java
@@ -53,7 +53,7 @@ public class AzureComputer extends AbstractCloudComputer<AzureSlave>  {
 	public HttpResponse doDoDelete() throws IOException {
 		LOGGER.info("AzureComputer: doDoDelete called for slave "+getNode().getNodeName());
 		setTemporarilyOffline(true, OfflineCause.create(Messages._Delete_Slave()));
-		getNode().setDeleteSlave(true);
+		getNode().setCleanupAction(CleanupAction.TERMINATE);
 		try {
 			deleteSlave();
 		} catch(Exception e) {
@@ -72,7 +72,7 @@ public class AzureComputer extends AbstractCloudComputer<AzureSlave>  {
 			slave.getChannel().close();
 		}
 		try {
-			slave.deprovision();
+			slave.cleanup();
 		} catch (Exception e) {
 			
 			LOGGER.severe("AzureComputer : Exception occurred while deleting  " + getName() + " slave");

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureManagementServiceDelegate.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureManagementServiceDelegate.java
@@ -528,7 +528,8 @@ public class AzureManagementServiceDelegate {
 					template.getJvmOptions(), template.isShutdownOnIdle(),
 					cloudServiceName, params.getName(),
 					template.getRetentionTimeInMin(), template.getInitScript(), azureCloud.getSubscriptionId(),
-					azureCloud.getServiceManagementCert(), azureCloud.getPassPhrase(), azureCloud.getServiceManagementURL(), template.getSlaveLaunchMethod(), false);
+					azureCloud.getServiceManagementCert(), azureCloud.getPassPhrase(), azureCloud.getServiceManagementURL(), 
+                    template.getSlaveLaunchMethod(), CleanupAction.NONE);
 		} catch (FormException e) {
 			e.printStackTrace();
 			throw new AzureCloudException("AzureManagementServiceDelegate: parseDeploymentResponse: Exception occured while creating slave object"+e);
@@ -563,7 +564,8 @@ public class AzureManagementServiceDelegate {
 					template.getJvmOptions(), template.isShutdownOnIdle(),
 					cloudServiceName, deploymentName,
 					template.getRetentionTimeInMin(), template.getInitScript(), azureCloud.getSubscriptionId(), azureCloud.getServiceManagementCert(),
-					azureCloud.getPassPhrase(), azureCloud.getServiceManagementURL(), template.getSlaveLaunchMethod(), false);
+					azureCloud.getPassPhrase(), azureCloud.getServiceManagementURL(), template.getSlaveLaunchMethod(), 
+                    CleanupAction.NONE);
 		} catch (FormException e) {
 			e.printStackTrace();
 			throw new AzureCloudException("AzureManagementServiceDelegate: parseResponse: Exception occured while creating slave object"+e);

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureSlave.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureSlave.java
@@ -24,6 +24,7 @@ import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import com.microsoftopentechnologies.azure.CleanupAction;
 import com.microsoftopentechnologies.azure.util.Constants;
 import com.microsoftopentechnologies.azure.util.FailureStage;
 import com.microsoftopentechnologies.azure.remote.AzureSSHLauncher;
@@ -63,7 +64,7 @@ public class AzureSlave extends AbstractCloudSlave  {
 	private  String passPhrase;
 	private  String managementURL;
 	private String templateName;
-	private boolean deleteSlave;
+    private CleanupAction cleanupAction;
 	private static final Logger LOGGER = Logger.getLogger(AzureSlave.class.getName());
 
 	@DataBoundConstructor
@@ -71,7 +72,7 @@ public class AzureSlave extends AbstractCloudSlave  {
 			ComputerLauncher launcher, RetentionStrategy<AzureComputer> retentionStrategy, List<? extends NodeProperty<?>> nodeProperties, 
 			String cloudName, String adminUserName, String sshPrivateKey, String sshPassPhrase, String adminPassword, String jvmOptions, 
 			boolean shutdownOnIdle, String cloudServiceName, String deploymentName, int retentionTimeInMin, String initScript, 
-			String subscriptionID, String managementCert, String passPhrase, String managementURL, String slaveLaunchMethod, boolean deleteSlave) throws FormException, IOException {
+			String subscriptionID, String managementCert, String passPhrase, String managementURL, String slaveLaunchMethod, CleanupAction cleanupAction) throws FormException, IOException {
 		super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
 		this.cloudName = cloudName;
 		this.templateName = templateName;
@@ -92,18 +93,18 @@ public class AzureSlave extends AbstractCloudSlave  {
 		this.passPhrase = passPhrase;
 		this.managementURL = managementURL;
 		this.slaveLaunchMethod = slaveLaunchMethod;
-		this.deleteSlave = deleteSlave;
+		this.cleanupAction = cleanupAction;
 	}
 	
 	public AzureSlave(String name, String templateName, String nodeDescription, String osType, String remoteFS, int numExecutors, Mode mode, String labelString,
 			String cloudName, String adminUserName, String sshPrivateKey, String sshPassPhrase, String adminPassword, String jvmOptions, 
 			boolean shutdownOnIdle, String cloudServiceName, String deploymentName, int retentionTimeInMin, String initScript, 
-			String subscriptionID, String managementCert, String passPhrase, String managementURL, String slaveLaunchMethod, boolean deleteSlave) throws FormException, IOException {
+			String subscriptionID, String managementCert, String passPhrase, String managementURL, String slaveLaunchMethod, CleanupAction cleanupAction) throws FormException, IOException {
 		this(name, templateName, nodeDescription, osType, remoteFS, numExecutors, mode, labelString, 
 				slaveLaunchMethod.equalsIgnoreCase("SSH")? osType.equalsIgnoreCase("Windows")? new AzureSSHLauncher():new AzureSSHLauncher() : new JNLPLauncher(),
 				new AzureCloudRetensionStrategy(retentionTimeInMin), Collections.<NodeProperty<?>> emptyList(), cloudName, adminUserName,
 				sshPrivateKey, sshPassPhrase, adminPassword, jvmOptions, shutdownOnIdle, cloudServiceName, deploymentName, retentionTimeInMin, initScript,
-				subscriptionID, managementCert, passPhrase, managementURL, slaveLaunchMethod, deleteSlave);
+				subscriptionID, managementCert, passPhrase, managementURL, slaveLaunchMethod, cleanupAction);
 		this.cloudName = cloudName;
 		this.templateName = templateName;
 		this.adminUserName = adminUserName;
@@ -122,7 +123,7 @@ public class AzureSlave extends AbstractCloudSlave  {
 		this.managementCert = managementCert;
 		this.passPhrase = passPhrase;
 		this.managementURL = managementURL;
-		this.deleteSlave = deleteSlave;
+		this.cleanupAction = cleanupAction;
 	}
 
 	public String getCloudName() {
@@ -177,12 +178,12 @@ public class AzureSlave extends AbstractCloudSlave  {
 		return adminPassword;
 	}
 
-	public boolean isDeleteSlave() {
-		return deleteSlave;
+	public CleanupAction getCleanupAction() {
+		return cleanupAction;
 	}
 
-	public void setDeleteSlave(boolean deleteSlave) {
-		this.deleteSlave = deleteSlave;
+	public void setCleanupAction(CleanupAction cleanupAction) {
+		this.cleanupAction = cleanupAction;
 	}
 
 	public String getJvmOptions() {
@@ -244,31 +245,35 @@ public class AzureSlave extends AbstractCloudSlave  {
 	
 	public void idleTimeout() throws Exception {
 		if (shutdownOnIdle) {
-			// Call shutdown only if the slave is online
-			if (this.getComputer().isOnline()) {
-				LOGGER.info("AzureSlave: idleTimeout: shutdownOnIdle is true, shutting down slave "+this.getDisplayName());
-				this.getComputer().disconnect(OfflineCause.create(Messages._IDLE_TIMEOUT_SHUTDOWN()));
-				AzureManagementServiceDelegate.shutdownVirtualMachine(this);
-				setDeleteSlave(false);
-			}
+            LOGGER.info("AzureSlave: idleTimeout: shutdownOnIdle is true, marking slave for shutdown: " + this.getDisplayName());
+            setCleanupAction(CleanupAction.SHUTDOWN);
+            this.getComputer().disconnect(OfflineCause.create(Messages._IDLE_TIMEOUT_SHUTDOWN()));
 		} else {
-			LOGGER.info("AzureSlave: idleTimeout: shutdownOnIdle is false, deleting slave "+this.getDisplayName());
-			setDeleteSlave(true);
-			AzureManagementServiceDelegate.terminateVirtualMachine(this, true);
-			Jenkins.getInstance().removeNode(this);
+			LOGGER.info("AzureSlave: idleTimeout: shutdownOnIdle is false, marking slave for deletion: " + this.getDisplayName());
+			setCleanupAction(CleanupAction.TERMINATE);
+            this.getComputer().setTemporarilyOffline(true, OfflineCause.create(Messages._Delete_Slave()));
 		}
-	}
+    }
+    
+    public void cleanup() throws Exception {
+        // Clean up the node.  If we are unsuccesful, then we simple skip and continue
+        if (getCleanupAction() == CleanupAction.TERMINATE) { 
+            LOGGER.info("AzureSlave: cleanup: Terminate called for slave " + this.getDisplayName());
+            AzureManagementServiceDelegate.terminateVirtualMachine(this, true);
+            Jenkins.getInstance().removeNode(this);
+        } else if (getCleanupAction() == CleanupAction.SHUTDOWN) {
+            // If we aren't to delete it, then we should just shut it down.
+            LOGGER.info("AzureSlave: cleanup: Shutdown called for slave " + this.getDisplayName());
+            AzureManagementServiceDelegate.shutdownVirtualMachine(this);
+        }
+        else {
+            LOGGER.info("AzureSlave: cleanup: Slave " + this.getDisplayName() + " is offline but not marked for shutdown/deletion.");
+        }
+    }
 	
 	public AzureCloud getCloud() {
     	return (AzureCloud) Jenkins.getInstance().getCloud(cloudName);
     }
-	
-	public void deprovision() throws Exception {
-		LOGGER.info("AzureSlave: deprovision: Deprovision called for slave "+this.getDisplayName());
-		AzureManagementServiceDelegate.terminateVirtualMachine(this, true);
-		setDeleteSlave(true);
-		Jenkins.getInstance().removeNode(this);
-	}
 	
 	public boolean isVMAliveOrHealthy() throws Exception {		
 		return AzureManagementServiceDelegate.isVMAliveOrHealthy(this);
@@ -294,8 +299,8 @@ public class AzureSlave extends AbstractCloudSlave  {
 				+ ", osType=" + osType + ", publicDNSName=" + publicDNSName
 				+ ", sshPort=" + sshPort + ", mode=" + mode
 				+ ", subscriptionID=" + subscriptionID + ", passPhrase=" + passPhrase
-				+ ", managementURL=" + managementURL + ", deleteSlave="
-				+ deleteSlave + "]";
+				+ ", managementURL=" + managementURL + ", cleanupAction="
+				+ cleanupAction + "]";
 	}
 
 	@Extension

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureSlave.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureSlave.java
@@ -260,11 +260,13 @@ public class AzureSlave extends AbstractCloudSlave  {
         if (getCleanupAction() == CleanupAction.TERMINATE) { 
             LOGGER.info("AzureSlave: cleanup: Terminate called for slave " + this.getDisplayName());
             AzureManagementServiceDelegate.terminateVirtualMachine(this, true);
+            LOGGER.info("AzureSlave: cleanup: Slave " + this.getDisplayName() + " succesfully deleted.");
             Jenkins.getInstance().removeNode(this);
         } else if (getCleanupAction() == CleanupAction.SHUTDOWN) {
             // If we aren't to delete it, then we should just shut it down.
             LOGGER.info("AzureSlave: cleanup: Shutdown called for slave " + this.getDisplayName());
             AzureManagementServiceDelegate.shutdownVirtualMachine(this);
+            LOGGER.info("AzureSlave: cleanup: Slave " + this.getDisplayName() + " succesfully shutdown.");
         }
         else {
             LOGGER.info("AzureSlave: cleanup: Slave " + this.getDisplayName() + " is offline but not marked for shutdown/deletion.");

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureSlaveCleanUpTask.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureSlaveCleanUpTask.java
@@ -40,14 +40,11 @@ public final class AzureSlaveCleanUpTask extends AsyncPeriodicWork {
 				AzureComputer azureComputer = (AzureComputer)computer;
 				final AzureSlave slaveNode = azureComputer.getNode();
 				
+                // Only clean up offline nodes.
 				if (azureComputer.isOffline()) {
 					if(AzureManagementServiceDelegate.isVirtualMachineExists(slaveNode)) {
-						if (!slaveNode.isDeleteSlave()) { 
-							continue; //If agent is not marked for deletion, it means it is active.
-						}
-						
 						try {
-							slaveNode.idleTimeout();
+							slaveNode.cleanup();
 				         } catch (AzureCloudException exception) {
 				        	// No need to throw exception back, just log and move on. 
 				        	 LOGGER.info("AzureSlaveCleanUpTask: execute: failed to remove node "+exception);

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureSlaveCleanUpTask.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureSlaveCleanUpTask.java
@@ -43,16 +43,26 @@ public final class AzureSlaveCleanUpTask extends AsyncPeriodicWork {
                 // Only clean up offline nodes.
 				if (azureComputer.isOffline()) {
 					if(AzureManagementServiceDelegate.isVirtualMachineExists(slaveNode)) {
-						try {
-							slaveNode.cleanup();
-				         } catch (AzureCloudException exception) {
-				        	// No need to throw exception back, just log and move on. 
-				        	 LOGGER.info("AzureSlaveCleanUpTask: execute: failed to remove node "+exception);
-				         } catch (Exception e) {
-							// TODO Auto-generated catch block
-				        	 LOGGER.info("AzureSlaveCleanUpTask: execute: failed to remove node "+e);
-						}
+                        // Retry 10 times, since there may be exclusive locks and cleaning up
+                        // is very valuable.
+                        int tries = 0;
+                        int maxTries = 10;
+                        do {
+                            try {
+                                slaveNode.cleanup();
+                                break;
+                            } catch (AzureCloudException exception) {
+                                // No need to throw exception back, just log and move on. 
+                                 LOGGER.info("AzureSlaveCleanUpTask: execute: failed to remove node (" + (maxTries-tries-1) + " tries remaining) " +exception);
+                            } catch (Exception e) {
+                                // TODO Auto-generated catch block
+                                LOGGER.info("AzureSlaveCleanUpTask: execute: failed to remove node (" + (maxTries-tries-1) + " tries remaining) " +e);
+                            }
+                            Thread.sleep(18 * 1000);
+                        }
+                        while (++tries < maxTries);
 					} else {
+                        LOGGER.info("AzureSlaveCleanUpTask: execute: removing node " + slaveNode.getNodeName());
 						Jenkins.getInstance().removeNode(slaveNode);
 					}
 				}

--- a/src/main/java/com/microsoftopentechnologies/azure/CleanupAction.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/CleanupAction.java
@@ -1,0 +1,27 @@
+/*
+ Copyright 2014 Microsoft Open Technologies, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.microsoftopentechnologies.azure;
+
+/**
+ *
+ * @author mmitche
+ */
+public enum CleanupAction {
+    NONE,
+	TERMINATE,
+	SHUTDOWN
+}

--- a/src/main/java/com/microsoftopentechnologies/azure/remote/AzureSSHLauncher.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/remote/AzureSSHLauncher.java
@@ -21,6 +21,7 @@ import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import com.microsoftopentechnologies.azure.AzureSlave;
 import com.microsoftopentechnologies.azure.AzureComputer;
+import com.microsoftopentechnologies.azure.CleanupAction;
 import com.microsoftopentechnologies.azure.Messages;
 import com.microsoftopentechnologies.azure.util.AzureUtil;
 import com.microsoftopentechnologies.azure.util.Constants;
@@ -79,7 +80,7 @@ public class AzureSSHLauncher extends ComputerLauncher {
 		} catch (Exception e) {
 			LOGGER.info("AzureSSHLauncher: launch: Got exception while connecting to slave " +e.getMessage());
 			LOGGER.info("AzureSSHLauncher: launch: marking slave for delete ");
-			slave.setDeleteSlave(true);
+			slave.setCleanupAction(CleanupAction.TERMINATE);
 			
 			// Checking if we need to mark template as disabled. Need to re-visit this logic based on tests.
 			if (e instanceof ConnectException) {
@@ -303,7 +304,7 @@ public class AzureSSHLauncher extends ComputerLauncher {
 		if (slave.toComputer() != null) {
 			slave.toComputer().setTemporarilyOffline(true, OfflineCause.create(Messages._Slave_Failed_To_Connect()));
 		}
-		slave.setDeleteSlave(true);
+		slave.setCleanupAction(CleanupAction.TERMINATE);
 	}
 
     @Override


### PR DESCRIPTION
Today we make calls to Azure while cleaning up the slaves.  This is problematic because calling Jenkins removeNode will (for some reason) call check on the node retention strategy for other nodes.  While removeNode is running, the Queue is locked.  If upon the nested check, we decide to remove a node, the call to Azure, which might take a number of seconds, will block the Queue.  This means in the meantime no builds can start, etc.  This is especially problematic becuase if other triggers/hooks start running, they may also block.  We may end up with a full set of HTTP requests being handled and waiting, meaning the website will appear down while the nodes are being deleted.

This change cleans this up.  First, I removed setDeleteSlave and replaced it with a separate CleanupAction enumeration to avoid overloading and hacky behavior.  Then, along the retention strategy path I removed all calls to delete the slave from azure, instead opting to set the machine offline and wait for the clean up task to come along and remove the node, which is done in a separate thread that will not end up with a blocking call with the queue locked.
