### PR TITLE
A couple fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jackson.version>2.5.4</jackson.version>
-    <azuresdk.version>0.8.0</azuresdk.version>
+    <azuresdk.version>0.9.4</azuresdk.version>
   </properties>
 
   <licenses>

--- a/src/main/java/com/microsoftopentechnologies/azure/AzureManagementServiceDelegate.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/AzureManagementServiceDelegate.java
@@ -189,7 +189,7 @@ public class AzureManagementServiceDelegate {
             }
 
             // Deployment ....
-            properties.setMode(DeploymentMode.INCREMENTAL);
+            properties.setMode(DeploymentMode.Incremental);
             properties.setTemplate(tmp.toString());
 
             final String deploymentName = String.valueOf(ts);

--- a/src/main/java/com/microsoftopentechnologies/azure/util/AccessToken.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/util/AccessToken.java
@@ -42,7 +42,8 @@ public class AccessToken implements Serializable {
         this.subscriptionId = subscriptionId;
         this.serviceManagementUrl = serviceManagementUrl;
         this.token = authres.getAccessToken();
-        this.expiration = authres.getExpiresOn();
+        // In the 0.9.4 version of the SDK, expiresOn is the number of ms till expire
+        this.expiration = System.currentTimeMillis() + authres.getExpiresOn();
     }
 
     public Configuration getConfiguration() throws AzureCloudException {
@@ -65,6 +66,10 @@ public class AccessToken implements Serializable {
 
     public boolean isExpiring() {
         return expiration < System.currentTimeMillis();
+    }
+
+    public String getToken() {
+        return token;
     }
 
     @Override

--- a/src/main/java/com/microsoftopentechnologies/azure/util/TokenCache.java
+++ b/src/main/java/com/microsoftopentechnologies/azure/util/TokenCache.java
@@ -189,8 +189,6 @@ public class TokenCache {
 
     private AccessToken getNewToken() throws AzureCloudException {
         LOGGER.log(Level.INFO, "Retrieve new access token");
-        // reset configuration instance: renew token
-        Configuration.setInstance(null);
 
         final ExecutorService service = Executors.newFixedThreadPool(1);
 
@@ -220,11 +218,12 @@ public class TokenCache {
             throw new AzureCloudException("Authentication result was null");
         }
 
-        LOGGER.log(Level.INFO,
-                "Authentication result:\n\taccess token: {0}\n\tExpires On: {1}",
-                new Object[] { authres.getAccessToken(), new Date(authres.getExpiresOn()) });
-
         final AccessToken token = new AccessToken(subscriptionId, serviceManagementURL, authres);
+
+        LOGGER.log(Level.INFO,
+                "Authentication result:\n\taccess token: {0}\n\tExpires In: {1}{2}",
+                new Object[] { token.getToken(), token.getExpirationDate()});
+
         writeTokenFile(token);
         return token;
     }


### PR DESCRIPTION
Update SDK to 0.9.4
Token expiration was incorrectly calculated (API is named a bit oddly)

/cc @HuanhuanSunMSFT 