### PR TITLE
Move to a static thread pool

### DIFF
--- a/src/main/java/com/microsoft/azure/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/AzureVMManagementServiceDelegate.java
@@ -62,8 +62,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -1158,10 +1156,8 @@ public class AzureVMManagementServiceDelegate {
         };
         verificationTaskList.add(callVerifyVirtualMachineImage);
 
-        ExecutorService executorService = Executors.newFixedThreadPool(verificationTaskList.size());
-
         try {
-            for (Future<String> validationResult : executorService.invokeAll(verificationTaskList)) {
+            for (Future<String> validationResult : AzureVMCloud.getThreadPool().invokeAll(verificationTaskList)) {
                 try {
                     // Get will block until time expires or until task completes
                     String result = validationResult.get(60, TimeUnit.SECONDS);

--- a/src/main/java/com/microsoft/azure/util/ExecutionEngine.java
+++ b/src/main/java/com/microsoft/azure/util/ExecutionEngine.java
@@ -15,9 +15,8 @@
  */
 package com.microsoft.azure.util;
 
+import com.microsoft.azure.AzureVMCloud;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -35,8 +34,7 @@ public class ExecutionEngine {
 
     public static <T> T executeWithRetry(final Callable<T> task, final RetryStrategy retryStrategy)
             throws AzureCloudException {
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
-        Future<T> result = executorService.submit(new RetryTask<T>(task, retryStrategy));
+        Future<T> result = AzureVMCloud.getThreadPool().submit(new RetryTask<T>(task, retryStrategy));
 
         try {
             if (retryStrategy.getMaxTimeoutInSeconds() == 0) {
@@ -48,16 +46,11 @@ public class ExecutionEngine {
             throw new AzureCloudException("Operation timed out: ", timeoutException);
         } catch (Exception ex) {
             throw new AzureCloudException(ex);
-        } finally {
-            executorService.shutdown();
         }
     }
 
     public static <T> Future<T> executeAsync(final Callable<T> task, final RetryStrategy retryStrategy)
             throws AzureCloudException {
-        final ExecutorService executorService = Executors.newSingleThreadExecutor();
-        final Future<T> res = executorService.submit(new RetryTask<T>(task, retryStrategy));
-        executorService.shutdown();
-        return res;
+        return AzureVMCloud.getThreadPool().submit(new RetryTask<T>(task, retryStrategy));
     }
 }

--- a/src/main/java/com/microsoft/azure/util/TokenCache.java
+++ b/src/main/java/com/microsoft/azure/util/TokenCache.java
@@ -18,6 +18,7 @@ package com.microsoft.azure.util;
 import com.microsoft.aad.adal4j.AuthenticationContext;
 import com.microsoft.aad.adal4j.AuthenticationResult;
 import com.microsoft.aad.adal4j.ClientCredential;
+import com.microsoft.azure.AzureVMCloud;
 import com.microsoft.azure.exceptions.AzureCloudException;
 import java.io.File;
 import java.nio.file.Path;
@@ -30,8 +31,6 @@ import java.io.ObjectOutputStream;
 import java.net.MalformedURLException;
 import java.nio.file.Paths;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -167,8 +166,6 @@ public class TokenCache {
     private AccessToken getNewToken() throws AzureCloudException {
         LOGGER.log(Level.FINEST, "TokenCache: getNewToken: Retrieve new access token");
 
-        final ExecutorService service = Executors.newFixedThreadPool(1);
-
         AuthenticationResult authres = null;
 
         try {
@@ -176,7 +173,7 @@ public class TokenCache {
 
             final ClientCredential credential = new ClientCredential(credentials.clientId.getPlainText(), credentials.clientSecret.getPlainText());
 
-            final Future<AuthenticationResult> future = new AuthenticationContext(credentials.oauth2TokenEndpoint.getPlainText(), false, service).
+            final Future<AuthenticationResult> future = new AuthenticationContext(credentials.oauth2TokenEndpoint.getPlainText(), false, AzureVMCloud.getThreadPool()).
                     acquireToken(credentials.serviceManagementURL, credential, null);
 
             authres = future.get();
@@ -186,8 +183,6 @@ public class TokenCache {
             throw new AzureCloudException("Authentication interrupted", e);
         } catch (ExecutionException e) {
             throw new AzureCloudException("Authentication execution failed", e);
-        } finally {
-            service.shutdown();
         }
 
         if (authres == null) {


### PR DESCRIPTION
Significantly reduces memory and thread pressure.